### PR TITLE
Removing runSnarkWorker

### DIFF
--- a/CodaClient.py
+++ b/CodaClient.py
@@ -130,7 +130,6 @@ class Client():
         stateHash
         peers
         userCommandsSent
-        runSnarkWorker
         proposePubkeys
         consensusTimeNow
         consensusTimeBestTip


### PR DESCRIPTION
Looks like `runSnarkWorker` was removed (also saw this error on my own query). Running `get_daemon_status()`

```
{
    "errors": [{
        "message": "Field 'runSnarkWorker' is not defined on type 'DaemonStatus'"
    }]
}
```

Works great after removing it.