### PR TITLE
Release 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mina-sdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for interacting with Mina Protocol nodes"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for 0.1.1.

Includes since 0.1.0:
- Fix \`GET_ACCOUNT_WITH_TOKEN\` token-arg type (\`UInt64\` → \`TokenId\`) and refresh schema snapshot — #26
- Harden two-layer GraphQL schema-drift checker (Mina-error classifier, infra-failure bucket, coverage gap on \`--strict\`, HTTP status check, etc.) — #27

Merging this PR enables \`gh release create v0.1.1\` which fires the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)